### PR TITLE
Added delete-child-hook

### DIFF
--- a/lib/Net/Server.pm
+++ b/lib/Net/Server.pm
@@ -1036,6 +1036,8 @@ sub _read_conf {
 
 sub other_child_died_hook {}
 
+sub delete_child_hook {}
+
 sub delete_child {
     my ($self, $pid) = @_;
     my $prop = $self->{'server'};
@@ -1049,6 +1051,8 @@ sub delete_child {
             $prop->{'children'}->{$pid}->{'sock'}->close;
         }
     }
+    
+    $self->delete_child_hook($pid);   # user customizable hook
 
     delete $prop->{'children'}->{$pid};
 }


### PR DESCRIPTION
When using the Preforked variants, it's not guaranteed that a child will hit the child_finish_hook subroutine.  Adding a user-customizable hook, within delete_child, allows a user to do some guaranteed clean up before generating new children.
